### PR TITLE
Fixes for ROS Iron

### DIFF
--- a/robot_specific_config/abb_irb1200_5_90_moveit_config/config/ompl_planning.yaml
+++ b/robot_specific_config/abb_irb1200_5_90_moveit_config/config/ompl_planning.yaml
@@ -1,6 +1,6 @@
 planning_plugin: ompl_interface/OMPLPlanner
 request_adapters: >-
-  default_planner_request_adapters/AddTimeParameterization
+  default_planner_request_adapters/AddTimeOptimalParameterization
   default_planner_request_adapters/ResolveConstraintFrames
   default_planner_request_adapters/FixWorkspaceBounds
   default_planner_request_adapters/FixStartStateBounds

--- a/robot_specific_config/abb_irb1300_10_115_moveit_config/config/kinematics.yaml
+++ b/robot_specific_config/abb_irb1300_10_115_moveit_config/config/kinematics.yaml
@@ -1,9 +1,10 @@
-manipulator:
-  kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
-  # optional parameters for caching:
-  max_cache_size: 10000
-  min_pose_distance: 1.0
-  min_joint_config_distance: 4.0
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.05
-  kinematics_solver_attempts: 3
+robot_description_kinematics:
+  manipulator:
+    kinematics_solver: cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin
+    # optional parameters for caching:
+    max_cache_size: 10000
+    min_pose_distance: 1.0
+    min_joint_config_distance: 4.0
+    kinematics_solver_search_resolution: 0.005
+    kinematics_solver_timeout: 0.05
+    kinematics_solver_attempts: 3

--- a/robot_specific_config/abb_irb1300_10_115_moveit_config/config/ompl_planning.yaml
+++ b/robot_specific_config/abb_irb1300_10_115_moveit_config/config/ompl_planning.yaml
@@ -1,6 +1,6 @@
 planning_plugin: ompl_interface/OMPLPlanner
 request_adapters: >-
-  default_planner_request_adapters/AddTimeParameterization
+  default_planner_request_adapters/AddTimeOptimalParameterization
   default_planner_request_adapters/ResolveConstraintFrames
   default_planner_request_adapters/FixWorkspaceBounds
   default_planner_request_adapters/FixStartStateBounds

--- a/robot_specific_config/abb_irb910sc_3_45_moveit_config/config/kinematics.yaml
+++ b/robot_specific_config/abb_irb910sc_3_45_moveit_config/config/kinematics.yaml
@@ -1,13 +1,14 @@
-manipulator:
-  kinematics_solver: pick_ik/PickIkPlugin
-  kinematics_solver_timeout: 0.5
-  kinematics_solver_attempts: 3
-  mode: global
-  rotation_scale: 0.5
-  position_threshold: 0.001
-  orientation_threshold: 0.01
-  gd_step_size: 0.0001
-  cost_threshold: 0.01
-  center_joints_weight: 0.0
-  avoid_joint_limits_weight: 0.0
-  minimal_displacement_weight: 0.005
+robot_description_kinematics:
+  manipulator:
+    kinematics_solver: pick_ik/PickIkPlugin
+    kinematics_solver_timeout: 0.5
+    kinematics_solver_attempts: 3
+    mode: global
+    rotation_scale: 0.5
+    position_threshold: 0.001
+    orientation_threshold: 0.01
+    gd_step_size: 0.0001
+    cost_threshold: 0.01
+    center_joints_weight: 0.0
+    avoid_joint_limits_weight: 0.0
+    minimal_displacement_weight: 0.005

--- a/robot_specific_config/abb_irb910sc_3_45_moveit_config/config/ompl_planning.yaml
+++ b/robot_specific_config/abb_irb910sc_3_45_moveit_config/config/ompl_planning.yaml
@@ -1,6 +1,6 @@
 planning_plugin: ompl_interface/OMPLPlanner
 request_adapters: >-
-  default_planner_request_adapters/AddTimeParameterization
+  default_planner_request_adapters/AddTimeOptimalParameterization
   default_planner_request_adapters/ResolveConstraintFrames
   default_planner_request_adapters/FixWorkspaceBounds
   default_planner_request_adapters/FixStartStateBounds


### PR DESCRIPTION
* `AddTimeParameterization` is gone as of https://github.com/ros-planning/moveit2/pull/1780  - this replaces it with `AddTimeOptimalParameterization`
* Prefix kinematics parameters with `robot_description_kinematics` - seems to be necessary after https://github.com/ros-planning/moveit2/pull/1568